### PR TITLE
Fix image alt text typo

### DIFF
--- a/_posts/2014-03-28-transactions-in-rails-data-migrations.markdown
+++ b/_posts/2014-03-28-transactions-in-rails-data-migrations.markdown
@@ -7,7 +7,7 @@ categories:
 
 Just found a useful idea in my friend’s code: **use transactions in database migrations**. This can save you a lot of trouble with partially updated data.
 
-![Person givin a credit card to a computer](https://s3.amazonaws.com/shovik-com/uploads/post_images/2/internet-1593384_1280.jpg?v=63658144892)
+![Person giving a credit card to a computer](https://s3.amazonaws.com/shovik-com/uploads/post_images/2/internet-1593384_1280.jpg?v=63658144892)
 
 I have 2 major types of DB migrations in my Rails applications:
 


### PR DESCRIPTION
## Summary
- correct a typo in the alt text for an image in the Rails migrations post

## Testing
- `grep -n "Person giving" _posts/2014-03-28-transactions-in-rails-data-migrations.markdown`
